### PR TITLE
Allow missing glyph files for get_named_font_stack.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pbf_font_tools"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "futures",
  "glob",

--- a/pbf_font_tools/Cargo.toml
+++ b/pbf_font_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbf_font_tools"
-version = "2.4.0"
+version = "2.5.0"
 description = "Tools for working with SDF font glyphs encoded in protobuf format."
 readme = "README.md"
 keywords = ["sdf", "protobuf", "fonts"]

--- a/pbf_font_tools/tests/integration_tests.rs
+++ b/pbf_font_tools/tests/integration_tests.rs
@@ -23,6 +23,30 @@ async fn test_load_glyphs() {
 }
 
 #[tokio::test]
+async fn test_get_named_font_stack() {
+    let font_path = Path::new("tests").join("glyphs");
+    let fonts = &["Empty Light", "SeoulNamsan L"];
+    let result = pbf_font_tools::get_named_font_stack(
+        font_path.as_path(),
+        fonts,
+        "Test".to_string(),
+        0,
+        255,
+    )
+    .await;
+
+    match result {
+        Ok(glyphs) => {
+            let stack = &glyphs.stacks[0];
+            let glyph_count = stack.glyphs.len();
+            assert_eq!(stack.name, Some(String::from(fonts[1])));
+            assert_eq!(glyph_count, 170);
+        }
+        Err(e) => panic!("Encountered error {e:#?}."),
+    }
+}
+
+#[tokio::test]
 async fn test_get_font_stack() {
     let font_path = Path::new("tests").join("glyphs");
     let font_names = vec!["SeoulNamsan L", "Open Sans Light"];


### PR DESCRIPTION
This ensures a valid result even when a font may be missing the _file_ (not just the contents) of a particular glyph range.

It also adds a test to verify the behavior.