### PR TITLE
A few more CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
@@ -32,12 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
 
       - name: Report Rust version
-        run: |
-          rustc --version
-          cargo --version
+        run: rustc --version && cargo --version
 
       - name: Run fmt
         run: cargo fmt --all -- --check
@@ -55,3 +56,33 @@ jobs:
         run: |
           cargo test --workspace --release --doc --locked
           RUSTDOCFLAGS="-D warnings" cargo doc --workspace --release --no-deps
+
+
+  multi-os-test:
+    name: Test on multiple OS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          # This is not an exhaustive list of runners, just the more recent ones
+          - ubuntu-latest
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - macos-latest
+          - macos-13
+          - macos-14  # M1 CPU
+          - windows-latest
+          - windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+
+      - name: Report Rust version
+        run: rustc --version && cargo --version
+
+      - name: Run tests
+        run: cargo test --workspace --all-features --locked

--- a/pbf_font_tools/tests/integration_tests.rs
+++ b/pbf_font_tools/tests/integration_tests.rs
@@ -99,7 +99,7 @@ async fn test_get_font_stack() {
                         namsan_glyph.eq(&glyph.bitmap.clone().unwrap()),
                         "Encountered glyph where Namsan was overwritten by Open Sans."
                     );
-                } else if open_sans_mapping.get(&glyph.id.unwrap()).is_some() {
+                } else if open_sans_mapping.contains_key(&glyph.id.unwrap()) {
                     has_open_sans_glyph = true;
                 } else {
                     panic!("Uh, where did this glyph come from?");


### PR DESCRIPTION
I recently got a runtime error in martin in macos-latest runner https://github.com/maplibre/martin/actions/runs/9232099619/job/25402973412 -- trying to see if its from here

```
dyld[12895]: Library not loaded: /usr/local/opt/freetype/lib/libfreetype.6.dylib
  Referenced from: <6F45087B-9511-3676-8E75-D8901573A921> /Users/runner/work/martin/martin/target/martin
  Reason: tried: '/usr/local/opt/freetype/lib/libfreetype.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/freetype/lib/libfreetype.6.dylib' (no such file), '/usr/local/opt/freetype/lib/libfreetype.6.dylib' (no such file), '/usr/local/lib/libfreetype.6.dylib' (no such file), '/usr/lib/libfreetype.6.dylib' (no such file, not in dyld cache)
```

As a minor cleanup:
* bumped to v4 of the checkout
* added rust build cache (except for releases)
* fixed clippy lint