### PR TITLE
Switch to Prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,8 @@ name = "build_pbf_glyphs"
 version = "1.4.2"
 dependencies = [
  "clap",
- "num_cpus",
  "pbf_font_tools",
- "protobuf",
+ "prost",
  "serde_json",
  "spmc",
  "tokio",
@@ -327,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "freetype-rs"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,7 +451,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -454,12 +459,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
@@ -484,21 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +490,17 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -556,12 +551,6 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -588,22 +577,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -638,13 +634,21 @@ name = "pbf_font_tools"
 version = "2.5.1"
 dependencies = [
  "futures",
- "glob",
- "protobuf",
- "protobuf-codegen",
- "protoc-bin-vendored",
+ "prost",
+ "prost-build",
  "sdf_glyph_renderer",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -694,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,112 +717,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "3.7.2"
+name = "prost"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror",
+ "bytes",
+ "prost-derive",
 ]
 
 [[package]]
-name = "protobuf-codegen"
-version = "3.7.2"
+name = "prost-build"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "anyhow",
- "once_cell",
- "protobuf",
- "protobuf-parse",
- "regex",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf-parse"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
-dependencies = [
- "anyhow",
- "indexmap",
+ "heck",
+ "itertools 0.13.0",
  "log",
- "protobuf",
- "protobuf-support",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
  "tempfile",
- "thiserror",
- "which",
 ]
 
 [[package]]
-name = "protobuf-support"
-version = "3.7.2"
+name = "prost-derive"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
- "thiserror",
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
-name = "protoc-bin-vendored"
-version = "3.1.0"
+name = "prost-types"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd89a830d0eab2502c81a9b8226d446a52998bb78e5e33cb2637c0cdd6068d99"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-aarch_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
+ "prost",
 ]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f563627339f1653ea1453dfbcb4398a7369b768925eb14499457aeaa45afe22c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5025c949a02cd3b60c02501dd0f348c16e8fff464f2a7f27db8a9732c608b746"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9500ce67d132c2f3b572504088712db715755eb9adf69d55641caa2cb68a07"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5462592380cefdc9f1f14635bcce70ba9c91c1c2464c7feb2ce564726614cc41"
-
-[[package]]
-name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c637745681b68b4435484543667a37606c95ddacf15e917710801a0877506030"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38943f3c90319d522f94a6dfd4a134ba5e36148b9506d2d9723a82ebc57c8b55"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
 name = "quote"
@@ -882,19 +840,6 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -902,7 +847,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys",
 ]
 
@@ -1015,24 +960,24 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,13 +996,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -1093,6 +1042,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1169,18 +1124,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pbf_font_tools"
-version = "2.5.1"
+version = "3.0.0"
 dependencies = [
  "futures",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ rust-version = "1.81.0"
 clap = { version = "4.5.0", features = ["cargo", "derive"] }
 freetype-rs = { version = "0.35.0" }
 futures = "0.3.28"
-pbf_font_tools = { version = "2.3.0", features = ["freetype"], path = "pbf_font_tools" }
+pbf_font_tools = { path = "pbf_font_tools", features = ["freetype"] }
 prost = "0.14.1"
 prost-build = "0.14.1"
 sdf_glyph_renderer = { version = "1.0.0", features = ["freetype"], path = "sdf_glyph_renderer" }
 serde_json = "1.0.100"
 spmc = "0.3.0"
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["rt", "fs"] }
+tokio = { version = "1.46.1", features = ["rt", "fs", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ futures = "0.3.28"
 glob = "0.3.1"
 num_cpus = "1.16.0"
 pbf_font_tools = { version = "2.3.0", features = ["freetype"], path = "pbf_font_tools" }
-protobuf = "3.2.0"
-protobuf-codegen = "3.2.0"
-protoc-bin-vendored = "3.0.0"
+prost = "0.14.1"
+prost-build = "0.14.1"
 sdf_glyph_renderer = { version = "1.0.0", features = ["freetype"], path = "sdf_glyph_renderer" }
 serde_json = "1.0.100"
 spmc = "0.3.0"
-thiserror = "1.0.41"
-tokio = { version = "1.29.1", features = ["rt"] }
+thiserror = "2.0.12"
+tokio = { version = "1.46.1", features = ["rt", "fs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.28"
 pbf_font_tools = { path = "pbf_font_tools", features = ["freetype"] }
 prost = "0.14.1"
 prost-build = "0.14.1"
-sdf_glyph_renderer = { version = "1.0.0", features = ["freetype"], path = "sdf_glyph_renderer" }
+sdf_glyph_renderer = { path = "sdf_glyph_renderer", features = ["freetype"] }
 serde_json = "1.0.100"
 spmc = "0.3.0"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ rust-version = "1.81.0"
 clap = { version = "4.5.0", features = ["cargo", "derive"] }
 freetype-rs = { version = "0.35.0" }
 futures = "0.3.28"
-glob = "0.3.1"
-num_cpus = "1.16.0"
 pbf_font_tools = { version = "2.3.0", features = ["freetype"], path = "pbf_font_tools" }
 prost = "0.14.1"
 prost-build = "0.14.1"

--- a/build_pbf_glyphs/Cargo.toml
+++ b/build_pbf_glyphs/Cargo.toml
@@ -13,9 +13,8 @@ license.workspace = true
 
 [dependencies]
 clap.workspace = true
-num_cpus.workspace = true
 pbf_font_tools.workspace = true
-protobuf.workspace = true
+prost.workspace = true
 serde_json.workspace = true
 spmc.workspace = true
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }

--- a/build_pbf_glyphs/src/main.rs
+++ b/build_pbf_glyphs/src/main.rs
@@ -11,9 +11,9 @@
 //! [sdf_glyph_renderer](https://github.com/stadiamaps/sdf_glyph_renderer) for more technical
 //! details on how this works.
 //!
-//! NOTE: This has requires you to have `FreeType` installed on your system. We recommend using
+//! NOTE: This requires you to have `FreeType` installed on your system. We recommend using
 //! `FreeType` 2.10 or newer. Everything will still work against many older 2.x versions, but
-//! the glyph generation improves over time so things will generally look better with newer
+//! the glyph generation improves over time, so things will generally look better with newer
 //! versions.
 //!
 //! ## Usage
@@ -187,7 +187,7 @@ fn main() {
     let out_dir = &args.out_dir;
 
     let (mut tx, rx) = channel();
-    let num_threads = num_cpus::get();
+    let num_threads = thread::available_parallelism().unwrap().get();
     println!("Starting {num_threads} worker threads...");
 
     let join_handles: Vec<_> = (0..num_threads)

--- a/build_pbf_glyphs/src/main.rs
+++ b/build_pbf_glyphs/src/main.rs
@@ -27,17 +27,19 @@
 //! ```
 
 use std::collections::HashMap;
-use std::fs::{create_dir_all, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::Instant;
+use tokio::fs::{create_dir_all, File};
 
 use clap::{command, Parser};
 use pbf_font_tools::freetype::{Face, Library};
 use pbf_font_tools::{get_named_font_stack, glyph_range_for_face, Glyphs};
-use protobuf::{CodedOutputStream, Message};
+use prost::Message;
 use spmc::{channel, Receiver};
+use tokio::io::AsyncWriteExt;
 
 static TOTAL_GLYPHS_RENDERED: AtomicUsize = AtomicUsize::new(0);
 
@@ -62,7 +64,9 @@ struct Args {
 /// The font name list will be used as the order of precedence.
 async fn combine_glyphs(font_path: &Path, font_names: &[&str], stack_name: String) {
     let out_dir = font_path.join(&stack_name);
-    create_dir_all(&out_dir).expect("Unable to create output directory");
+    create_dir_all(&out_dir)
+        .await
+        .expect("Unable to create output directory");
 
     let mut start = 0;
     let mut end = 255;
@@ -76,11 +80,13 @@ async fn combine_glyphs(font_path: &Path, font_names: &[&str], stack_name: Strin
         // The above utility always returns a single stack
         glyphs_combined += stack.stacks[0].glyphs.len();
 
+        let encoded_bytes = stack.encode_to_vec();
         let mut file = File::create(out_dir.join(format!("{start}-{end}.pbf")))
+            .await
             .expect("Unable to create file");
-        let mut cos = CodedOutputStream::new(&mut file);
-        stack.write_to(&mut cos).expect("Unable to write");
-        cos.flush().expect("Unable to flush");
+        file.write_all(&encoded_bytes)
+            .await
+            .expect("Unable to write to file");
 
         start += 256;
         end += 256;
@@ -108,7 +114,7 @@ fn render_worker(
 
     while let Ok(Some((path, stem))) = rx.recv() {
         let out_dir = base_out_dir.join(stem.to_str().expect("Unable to extract file stem"));
-        create_dir_all(&out_dir).expect("Unable to create output directory");
+        std::fs::create_dir_all(&out_dir).expect("Unable to create output directory");
 
         println!("Processing {}", path.display());
 
@@ -138,7 +144,7 @@ fn render_worker(
             if !overwrite && glyph_path.exists() {
                 glyphs_skipped += 256;
             } else {
-                let mut glyphs = Glyphs::new();
+                let mut glyphs = Glyphs::default();
 
                 for (face_index, face) in faces.iter().enumerate() {
                     if let Ok(stack) = glyph_range_for_face(face, start, end, 24, radius, cutoff) {
@@ -151,10 +157,10 @@ fn render_worker(
                     }
                 }
 
-                let mut file = File::create(glyph_path).expect("Unable to create file");
-                let mut cos = CodedOutputStream::new(&mut file);
-                glyphs.write_to(&mut cos).expect("Unable to write");
-                cos.flush().expect("Unable to flush");
+                let encoded_bytes = glyphs.encode_to_vec();
+                let mut file = std::fs::File::create(glyph_path).expect("Unable to create file");
+                file.write_all(&encoded_bytes)
+                    .expect("Unable to write to file");
             }
 
             start += 256;

--- a/pbf_font_tools/Cargo.toml
+++ b/pbf_font_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbf_font_tools"
-version = "2.5.1"
+version = "3.0.0"
 description = "Tools for working with SDF font glyphs encoded in protobuf format."
 readme = "README.md"
 keywords = ["sdf", "protobuf", "fonts"]

--- a/pbf_font_tools/Cargo.toml
+++ b/pbf_font_tools/Cargo.toml
@@ -16,7 +16,7 @@ freetype = ["dep:sdf_glyph_renderer"]
 
 [dependencies]
 futures.workspace = true
-protobuf.workspace = true
+prost.workspace = true
 sdf_glyph_renderer = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
@@ -25,6 +25,4 @@ tokio.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros"] }
 
 [build-dependencies]
-glob.workspace = true
-protobuf-codegen.workspace = true
-protoc-bin-vendored.workspace = true
+prost-build.workspace = true

--- a/pbf_font_tools/build.rs
+++ b/pbf_font_tools/build.rs
@@ -1,13 +1,6 @@
-use protoc_bin_vendored::protoc_bin_path;
+use std::io::Result;
 
-fn main() {
-    let mut codegen = protobuf_codegen::Codegen::new();
-    codegen
-        .cargo_out_dir("protos")
-        .input("proto/glyphs.proto")
-        .include("proto/");
-    if let Ok(vendored_protoc) = protoc_bin_path() {
-        codegen.protoc_path(&vendored_protoc);
-    }
-    codegen.run().expect("Protobuf codegen failed.");
+fn main() -> Result<()> {
+    prost_build::compile_protos(&["proto/glyphs.proto"], &["proto/"])?;
+    Ok(())
 }

--- a/pbf_font_tools/src/error.rs
+++ b/pbf_font_tools/src/error.rs
@@ -3,7 +3,7 @@ pub enum PbfFontError {
     #[error("Sub-process error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
     #[error("Protobuf decoding error: {0}")]
-    ProtobufError(#[from] protobuf::Error),
+    ProtobufError(#[from] prost::DecodeError),
     #[cfg(feature = "freetype")]
     #[error("SDF glyph error: {0}")]
     SdfGlyphError(#[from] sdf_glyph_renderer::SdfGlyphError),
@@ -12,4 +12,6 @@ pub enum PbfFontError {
     #[cfg(feature = "freetype")]
     #[error("Freetype error: {0}")]
     FreetypeError(#[from] crate::freetype::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }

--- a/pbf_font_tools/src/ft_generate.rs
+++ b/pbf_font_tools/src/ft_generate.rs
@@ -15,14 +15,14 @@ pub fn render_sdf_glyph(
 ) -> Result<Glyph, PbfFontError> {
     let glyph = render_sdf_from_face(face, char_code, buffer, radius)?;
 
-    let mut result = Glyph::new();
-    result.set_id(char_code);
-    result.set_bitmap(clamp_to_u8(&glyph.sdf, cutoff)?);
-    result.set_width(glyph.metrics.width as u32);
-    result.set_height(glyph.metrics.height as u32);
-    result.set_left(glyph.metrics.left_bearing);
-    result.set_top(glyph.metrics.top_bearing - glyph.metrics.ascender);
-    result.set_advance(glyph.metrics.h_advance);
+    let mut result = Glyph::default();
+    result.id = char_code;
+    result.bitmap = Some(clamp_to_u8(&glyph.sdf, cutoff)?);
+    result.width = glyph.metrics.width as u32;
+    result.height = glyph.metrics.height as u32;
+    result.left = glyph.metrics.left_bearing;
+    result.top = glyph.metrics.top_bearing - glyph.metrics.ascender;
+    result.advance = glyph.metrics.h_advance;
 
     Ok(result)
 }
@@ -54,9 +54,9 @@ pub fn glyph_range_for_face(
         family_name.push_str(&style_name);
     }
 
-    let mut stack = Fontstack::new();
-    stack.set_name(family_name);
-    stack.set_range(format!("{start}-{end}"));
+    let mut stack = Fontstack::default();
+    stack.name = family_name;
+    stack.range = format!("{start}-{end}");
 
     // FreeType conventions: char width or height of zero means "use the same value"
     // and setting both resolution values to zero results in the default value
@@ -97,7 +97,7 @@ pub fn glyph_range_for_font<P: AsRef<Path>>(
     let mut face = lib.new_face(font_path.as_ref(), 0)?;
     let num_faces = face.num_faces();
 
-    let mut result = Glyphs::new();
+    let mut result = Glyphs::default();
     result.stacks.reserve(num_faces as usize);
 
     for face_index in 0..num_faces {

--- a/pbf_font_tools/src/lib.rs
+++ b/pbf_font_tools/src/lib.rs
@@ -16,9 +16,9 @@ mod tools;
 
 #[cfg(feature = "freetype")]
 mod ft_generate;
-pub use proto::glyphs::{Fontstack, Glyph, Glyphs};
+pub use proto::{Fontstack, Glyph, Glyphs};
 // Re-export protobuf lib
-pub use protobuf;
+pub use prost;
 // Re-export freetype lib
 #[cfg(feature = "freetype")]
 pub use sdf_glyph_renderer::freetype;

--- a/pbf_font_tools/src/proto/mod.rs
+++ b/pbf_font_tools/src/proto/mod.rs
@@ -2,4 +2,4 @@
 
 #![allow(clippy::pedantic)]
 
-include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
+include!(concat!(env!("OUT_DIR"), "/llmr.glyphs.rs"));

--- a/pbf_font_tools/src/tools.rs
+++ b/pbf_font_tools/src/tools.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
-use std::fs::File;
+use std::ops::Deref;
 use std::path::Path;
+use tokio::fs::File;
 
 use futures::future::join_all;
-use protobuf::Message;
+use prost::Message;
+use tokio::io::AsyncReadExt;
 use tokio::task::spawn_blocking;
 
-use crate::proto::glyphs::{Fontstack, Glyphs};
+use crate::proto::{Fontstack, Glyphs};
 use crate::PbfFontError;
 use crate::PbfFontError::MissingFontFamilyName;
 
@@ -43,11 +45,11 @@ pub async fn get_named_font_stack<P: AsRef<Path>>(
         .await?
         .unwrap_or_else(|| {
             // Construct an empty message manually if the range is not covered
-            let mut result = Glyphs::new();
+            let mut result = Glyphs::default();
 
-            let mut stack = Fontstack::new();
-            stack.set_name(stack_name);
-            stack.set_range(format!("{start}-{end}"));
+            let mut stack = Fontstack::default();
+            stack.name = stack_name;
+            stack.range = format!("{start}-{end}");
 
             result.stacks.push(stack);
             result
@@ -78,13 +80,10 @@ pub async fn load_glyphs<P: AsRef<Path>>(
         .join(font_name)
         .join(format!("{start}-{end}.pbf"));
 
-    // Note: Counter-intuitively, it's much faster to use blocking IO with `spawn_blocking` here,
-    // since the `Message::parse_` call will block as well.
-    Ok(spawn_blocking(|| {
-        let mut file = File::open(full_path)?;
-        Message::parse_from_reader(&mut file)
-    })
-    .await??)
+    let mut file = File::open(full_path).await?;
+    let mut bytes = Vec::with_capacity(file.metadata().await?.len() as usize);
+    file.read_to_end(&mut bytes).await?;
+    Glyphs::decode(bytes.deref()).map_err(PbfFontError::from)
 }
 
 /// Combines a list of SDF font glyphs into a single glyphs message.
@@ -96,32 +95,31 @@ pub async fn load_glyphs<P: AsRef<Path>>(
 /// construct an empty message, the responsibility lies with the caller.
 #[must_use]
 pub fn combine_glyphs(glyphs_to_combine: Vec<Glyphs>) -> Option<Glyphs> {
-    let mut result = Glyphs::new();
-    let mut combined_stack = Fontstack::new();
+    let mut result = Glyphs::default();
+    let mut combined_stack = Fontstack::default();
     let mut coverage: HashSet<u32> = HashSet::new();
     let mut start = u32::MAX;
     let mut end = u32::MIN;
 
     for mut glyph_stack in glyphs_to_combine {
         for mut font_stack in glyph_stack.stacks.drain(..) {
-            if combined_stack.has_name() {
-                let name = combined_stack.mut_name();
-                name.push_str(", ");
-                name.push_str(&font_stack.take_name());
+            if combined_stack.name.is_empty() {
+                combined_stack.name = font_stack.name;
             } else {
-                combined_stack.set_name(font_stack.take_name());
+                let name = &mut combined_stack.name;
+                name.push_str(", ");
+                name.push_str(&font_stack.name)
             }
 
             for glyph in font_stack.glyphs.drain(..) {
-                if let Some(id) = glyph.id {
-                    if coverage.insert(id) {
-                        combined_stack.glyphs.push(glyph);
-                        if id < start {
-                            start = id;
-                        }
-                        if id > end {
-                            end = id;
-                        }
+                let id = glyph.id;
+                if coverage.insert(id) {
+                    combined_stack.glyphs.push(glyph);
+                    if id < start {
+                        start = id;
+                    }
+                    if id > end {
+                        end = id;
                     }
                 }
             }
@@ -132,7 +130,7 @@ pub fn combine_glyphs(glyphs_to_combine: Vec<Glyphs>) -> Option<Glyphs> {
         return None;
     }
 
-    combined_stack.set_range(format!("{start}-{end}"));
+    combined_stack.range = format!("{start}-{end}");
     result.stacks.push(combined_stack);
 
     Some(result)

--- a/pbf_font_tools/tests/integration_tests.rs
+++ b/pbf_font_tools/tests/integration_tests.rs
@@ -15,7 +15,7 @@ async fn test_load_glyphs() {
         Ok(glyphs) => {
             let stack = &glyphs.stacks[0];
             let glyph_count = stack.glyphs.len();
-            assert_eq!(stack.name, Some(String::from(font_name)));
+            assert_eq!(stack.name, String::from(font_name));
             assert_eq!(glyph_count, 170);
         }
         Err(e) => panic!("Encountered error {e:#?}."),
@@ -39,7 +39,7 @@ async fn test_get_named_font_stack() {
         Ok(glyphs) => {
             let stack = &glyphs.stacks[0];
             let glyph_count = stack.glyphs.len();
-            assert_eq!(stack.name, Some(String::from(fonts[1])));
+            assert_eq!(stack.name, String::from(fonts[1]));
             assert_eq!(glyph_count, 170);
         }
         Err(e) => panic!("Encountered error {e:#?}."),
@@ -65,41 +65,33 @@ async fn test_get_font_stack() {
             let stack = &combined_glyphs.stacks[0];
             let glyph_count = stack.glyphs.len();
 
-            assert_eq!(
-                stack.name,
-                Some(String::from("SeoulNamsan L, Open Sans Light"))
-            );
+            assert_eq!(stack.name, String::from("SeoulNamsan L, Open Sans Light"));
             assert_eq!(glyph_count, 228);
 
             let namsan_stack = &namsan_glyphs.stacks[0];
             let namsan_mapping: HashMap<u32, Vec<u8>> = namsan_stack
                 .glyphs
                 .iter()
-                .map(|x| {
-                    (
-                        x.id.expect("No id present"),
-                        x.bitmap.clone().expect("No bitmap"),
-                    )
-                })
+                .map(|x| (x.id, x.bitmap.clone().expect("No bitmap")))
                 .collect();
 
             let open_sans_stack = &open_sans_glyphs.stacks[0];
             let open_sans_mapping: HashMap<u32, Vec<u8>> = open_sans_stack
                 .glyphs
                 .iter()
-                .map(|x| (x.id.unwrap(), x.bitmap.clone().unwrap()))
+                .map(|x| (x.id, x.bitmap.clone().unwrap()))
                 .collect();
 
             let mut has_open_sans_glyph = false;
 
             // Make sure the Namsan font glyphs took precedence over the Open Sans ones.
             for glyph in &stack.glyphs {
-                if let Some(namsan_glyph) = namsan_mapping.get(&glyph.id.unwrap()) {
+                if let Some(namsan_glyph) = namsan_mapping.get(&glyph.id) {
                     assert!(
                         namsan_glyph.eq(&glyph.bitmap.clone().unwrap()),
                         "Encountered glyph where Namsan was overwritten by Open Sans."
                     );
-                } else if open_sans_mapping.contains_key(&glyph.id.unwrap()) {
+                } else if open_sans_mapping.contains_key(&glyph.id) {
                     has_open_sans_glyph = true;
                 } else {
                     panic!("Uh, where did this glyph come from?");


### PR DESCRIPTION
This switches to prost, a tokio project, for protobuf parsing and codegen. Also cleans up a few deps. (This is NOT as ambitious of an upgrade as some other PRs, so hopefully CI passes without a hitch.)

This crate is maintained under the tokio umbrella, and I expect would resolve a complaint in issue #21 by switching to a pure Rust dependency.

On speed, I have seen claims that this crate is faster than some others for _decoding_, but I could not verify those. When running `build_pbf_glyphs` on this branch vs `main`, there is no measurable difference (~1% variance between runs on my M1 Max). I verified the generated directory trees (sha256 hashes of the files) for the font set we use at Stadia Maps and they match.